### PR TITLE
Removed the sample Action for partners

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Learn more about GitHub Actions [here](https://github.com/features/actions).
 
 |Category|Partner|Action|Description|Security Policy|
 |-|-|-|-|-|
-|Android|XYZ Corp|[Android Builder](https://github.com/xyz-corp/android-builder)|A powerful tool to automate Android builds|[Security Policy](https://github.com/xyz-corp/android-builder/blob/main/SECURITY.md)|
 |Code review|Mergify|[Add Linear author as reviewer](https://github.com/Mergifyio/gha-add-linear-author-as-reviewer)|A GitHub action that request review of the Linear issue author.|[Security Policy](https://github.com/Mergifyio/gha-add-linear-author-as-reviewer/blob/main/SECURITY.md)|
 
 # Best Practices


### PR DESCRIPTION
Removed the sample action "Android Builder" as there are now entries from partners to serve as examples for others.